### PR TITLE
fix a typo in aardtools doc

### DIFF
--- a/doc/aardtools.rst
+++ b/doc/aardtools.rst
@@ -239,7 +239,7 @@ Unpack it::
 
 and compile::
 
-  aard wordnet WordNet-3.0	
+  aardc wordnet WordNet-3.0	
 
 .. _WordNet: http://wordnet.princeton.edu/
 


### PR DESCRIPTION
In the aardtools doc, `aardc` is mistakenly typed as `aard`.
